### PR TITLE
Update tool_glossary.rst

### DIFF
--- a/docs/source/tool_glossary.rst
+++ b/docs/source/tool_glossary.rst
@@ -9,8 +9,8 @@ Tools Glossary
 `MatNWB <https://github.com/NeurodataWithoutBorders/matnwb>`_
   A MATLAB library for reading and writing NWB files.
 
-`NWB Conversion Tools <https://nwb-conversion-tools.readthedocs.io/en/master/index.html>`_
-  A Python library for automatic conversion from proprietary data formats
+`NWB Conversion Tools <https://nwb-conversion-tools.readthedocs.io/en/main/index.html>`_
+  A Python library for automatic conversion from proprietary data formats.
 
 `NWB Inspector <https://github.com/NeurodataWithoutBorders/nwbinspector>`_
-  A Python and command-line tool for inspecting NWB files for adherence to NWB Best Practices
+  A Python and command-line tool for inspecting NWB files for adherence to NWB Best Practices.


### PR DESCRIPTION
@bendichter 

So sorry, I just found out earlier that the nwbct readthedocs were building on the previous master branch instead of main, it's all fixed now but this is a fix to the link so it can stay up to date.

Also, I have it configured on nwbct now that it will update the readthedocs on every PR, so no need to worry about doing manual build triggers.

