### PR TITLE
Standardize use of external links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,4 +153,7 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+# PyCharm
+.idea/
+
 # End of https://www.toptal.com/developers/gitignore/api/python,jupyternotebooks

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-To build locally, run 
+To build locally, run
 
 ```bash
 sphinx-build -a docs/source build
@@ -7,3 +7,53 @@ sphinx-build -a docs/source build
 Read the tutorial here:
 
 https://docs.readthedocs.io/en/stable/tutorial/
+
+External links
+==============
+
+Adding new external links
+-------------------------
+
+For managing links to external resources we use the :ref:`extlinks <https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html>` of sphinx. The mapping of links is defined in the ``/docs/source/conf_extlinks.py`` as part of ``extlinks`` dictionary. To update or add a new link edit the ``extlinks`` dictionary. For example, ``extlinks`` includes the entry
+
+.. code-block:
+
+    extlinks = {
+        'incf_collection': ('https://training.incf.org/collection/neurodata-without-borders-neurophysiology-nwbn', ''),
+        'pynwb_issue': ('https://github.com/NeurodataWithoutBorders/pynwb/issues/%s', 'pynwb#%s')
+    }
+
+The key in the dict defines the alias name as a new role so that we can writhe ``:pynwb_issue:```` to create a link. The value is the dict are a tuple consisting of the ``URL`` and the ``caption``.
+
+* **URL** The ``URL`` may contain ``%s`` once to extend the URL, e.g, in the case of linking to issues we need to add the issue number.
+* **Caption**:
+   * ``None`` : The the link caption rendered in the docs is the full URL
+   * ``''`` : The link caption in the text is the custom text indicated in the role
+   * ``text%s`` :  If the ``caption`` is a string, then it must contain ``%s`` exactly once. In this case the link caption is caption with the partial URL substituted for %s. E.g.,  in the above example, the link caption for pynwb issues would be issue pynwb#1.
+
+Creating external links in the docs
+-----------------------------------
+
+The ``extlinks`` dict in ``/docs/source/conf_extlinks.py`` defines a set of new roles. This allows us to refer, e.g., to specific usses in PyNWB via ``:pynwb_issue:`1``` which will in turn will be rendered as the text "pynwb#1" in the docs with the appropriate link to the issue. Similarly, if we want to refer to the INCF training we can write ``:incf_collection:`INCF Training``` in the text. Since the caption is an empty string in the ``extlinks`` dict for the ``incf_collection`` key, the link will be rendered using the provided text, i.e., here "INCF Training" with the approbriate link.
+
+Linking to external packages
+=============================
+
+Adding links to external packages
+--------------------------------0
+
+To link to specific entities (e.g., classes) in documentation of external software packages, we use the :ref:`intersphinx <https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html>` feature. The mapping to external docs is defined in ``/docs/source/conf_extlinks.py`` as part of the ``intersphinx_mapping`` dictionary. To support linking to a new tool, add the tool to the mapping.
+
+Creating external links to external packages in the docs
+--------------------------------------------------------
+
+Once the mapping is defined, we can refer to specific types much like we would refer to classes in our own tools. For example, the intersphinx mapping includes mappings for ``PynNWB`` and ``Pandas``:
+
+.. code-block:: python
+
+    intersphinx_mapping = {
+        'pynwb': ('https://pynwb.readthedocs.io/en/stable/', None),
+        'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
+    }
+
+With this we can now easly link to elements in those packages. E.g., to links to the docs of ``pandas.DataFrame`` we would write ``:py:class:`~pandas.DataFrame``` in the docs. Similarly, to link to ``NWBFile`` in ``PyNWB`` we would write ``:py:class:`~pynwb.file.NWBFile``` in the docs. When including the ``~`` we tell Sphinx to ignore the package when rendering in the text, i.e., ``:py:class:`~pynwb.file.NWBFile``` (with ``~``) will render as ``NWBFile`` in the docs, whereas ``:py:class:`pynwb.file.NWBFile``` (without ``~``) will render as the full name ``pynwb.file.NWBFile``.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2,6 +2,13 @@
 
 # -- Project information
 
+import sys
+import os
+sys.path.append(os.path.dirname(__file__))
+# Import the definition of external links
+from conf_extlinks import extlinks, intersphinx_mapping
+
+
 project = 'NWB Overview'
 copyright = ''
 author = 'Ben Dichter, ...'
@@ -20,24 +27,6 @@ extensions = [
     'myst_parser',
     'sphinx.ext.extlinks',
 ]
-
-intersphinx_mapping = {
-    'python': ('https://docs.python.org/3/', None),
-    'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
-    'numpy': ('https://numpy.org/doc/stable/', None),
-    'matplotlib': ('https://matplotlib.org', None),
-    'h5py': ('https://docs.h5py.org/en/latest/', None),
-    'hdmf': ('https://hdmf.readthedocs.io/en/latest/', None),
-    'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
-}
-
-extlinks = {
-    'incf_lesson': ('https://training.incf.org/lesson/%s', ''),
-    'incf_collection': ('https://training.incf.org/collection/%s', ''),
-    'nwb_extension': ('https://github.com/nwb-extensions/%s', ''),
-    'pynwb': ('https://github.com/NeurodataWithoutBorders/pynwb/%s', '')
-}
-
 
 intersphinx_disabled_domains = ['std']
 

--- a/docs/source/conf_extlinks.py
+++ b/docs/source/conf_extlinks.py
@@ -1,0 +1,22 @@
+# Use this for mapping to external links
+extlinks = {
+    'incf_collection': ('https://training.incf.org/collection/neurodata-without-borders-neurophysiology-nwbn', ''),
+    'nwb_extension_git': ('https://github.com/nwb-extensions/%s', ''),
+    'pynwb-issue': ('https://github.com/NeurodataWithoutBorders/pynwb/issues/%s', 'pynwb#%s'),
+    'pynwb-docs': ('https://pynwb.readthedocs.io/en/stable/', ''),
+    'matnwb-docs': ('https://neurodatawithoutborders.github.io/matnwb/', ''),
+    'nwbconversiontool-docs': ('https://nwb-conversion-tools.readthedocs.io/en/main/', ''),
+    'nwbinspector-docs': ('https://github.com/NeurodataWithoutBorders/nwbinspector', ''),
+}
+
+# Use this for mapping for links to commonly used documentation
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3/', None),
+    'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
+    'matplotlib': ('https://matplotlib.org', None),
+    'h5py': ('https://docs.h5py.org/en/latest/', None),
+    'hdmf': ('https://hdmf.readthedocs.io/en/latest/', None),
+    'pynwb': ('https://pynwb.readthedocs.io/en/stable/', None),
+    'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
+}

--- a/docs/source/tool_glossary.rst
+++ b/docs/source/tool_glossary.rst
@@ -3,14 +3,17 @@
 Tools Glossary
 --------------
 
-`PyNWB <https://pynwb.readthedocs.io/en/stable/>`_
+:pynwb-docs:`PyNWB`
+
   A Python library for reading, writing, and validating NWB files.
 
-`MatNWB <https://github.com/NeurodataWithoutBorders/matnwb>`_
+:matnwb-docs:`MatNWB`
+
   A MATLAB library for reading and writing NWB files.
 
-`NWB Conversion Tools <https://nwb-conversion-tools.readthedocs.io/en/master/index.html>`_
+:nwbconversiontool-docs:`NWB Conversion Tools`
   A Python library for automatic conversion from proprietary data formats
 
-`NWB Inspector <https://github.com/NeurodataWithoutBorders/nwbinspector>`_
+:nwbinspector-docs:`NWB Inspector`
+
   A Python and command-line tool for inspecting NWB files for adherence to NWB Best Practices


### PR DESCRIPTION
This PR moves the definitions of external links to a single file ``conf_extlinks.py`` so that we can more easily maintain links and adds documentation to the README to describe how to create and use external links. 