### PR TITLE
Add the extract tool to the page index

### DIFF
--- a/docs/source/tools/tools_home.rst
+++ b/docs/source/tools/tools_home.rst
@@ -17,6 +17,7 @@ Analysis and Visualization Tools
     caiman/caiman
     suite2p/suite2p
     ciatah/ciatah
+    extract/extract
     mies/mies
     deeplabcut/deeplabcut
     pynapple/pynapple


### PR DESCRIPTION
The Extract tool is missing in the page index so that it doesn't appear in the main menu.