### PR TITLE
Fix broken CaImAn link and add second demo

### DIFF
--- a/docs/source/tools/caiman/caiman.rst
+++ b/docs/source/tools/caiman/caiman.rst
@@ -6,7 +6,7 @@ CaImAn
 .. short_description_start
 
 :ref:`analysistools-caiman` is a computational toolbox for large scale Calcium Imaging Analysis, including movie
-handling, motion correction, source extraction, spike deconvolution and result visualization. CaImAn now supports reading and writing data in NWB 2.0. :bdg-link-primary:`NWB Demo  <https://github.com/flatironinstitute/CaImAn/blob/master/use_cases/NWB/demo_pipeline_nwb.ipynb>` :bdg-link-primary:`Video Tutorial <https://www.youtube.com/watch?v=wUhKkNtSu_s>` :bdg-link-primary:`Docs <https://caiman.readthedocs.io/en/master/>` :bdg-link-primary:`Source <https://github.com/flatironinstitute/CaImAn>`.
+handling, motion correction, source extraction, spike deconvolution and result visualization. CaImAn now supports reading and writing data in NWB 2.0. :bdg-link-primary:`NWB Demo  <https://github.com/flatironinstitute/caiman_use_cases/blob/main/use_cases/NWB/demo_pipeline_nwb.ipynb>` :bdg-link-primary:`Second Demo <https://github.com/flatironinstitute/CaImAn/blob/master/demos/general/demo_pipeline_NWB.py>` :bdg-link-primary:`Video Tutorial <https://www.youtube.com/watch?v=wUhKkNtSu_s>` :bdg-link-primary:`Docs <https://caiman.readthedocs.io/en/master/>` :bdg-link-primary:`Source <https://github.com/flatironinstitute/CaImAn>`.
 
 .. short_description_end
 


### PR DESCRIPTION
CaImAn moved their demo notebooks, including the one for NWB, into a new repo. This resulted in a broken link. This PR changes the link to point to the new repo and adds a second link to a demo python file in the main repo.