### PR TITLE
Fix broken link to Pynapple DANDI example.

### DIFF
--- a/docs/source/tools/pynapple/pynapple.rst
+++ b/docs/source/tools/pynapple/pynapple.rst
@@ -6,8 +6,8 @@ pynapple
 .. short_description_start
 
 :ref:`analysistools-pynapple` is a unified toolbox for integrated analysis of multiple data sources. Designed to be "plug & play", users define and import their own time-relevant variables. Supported data sources include, but are not limited to, electrophysiology, calcium imaging, and motion capture data. Pynapple contains integrated functions for common neuroscience analyses, including cross-correlograms, tuning curves, decoding and perievent time histogram.
-:bdg-link-primary:`Docs <https://pynapple-org.github.io/pynapple/>` :bdg-link-primary:`DANDI Demo Notebook <https://github.com/pynapple-org/pynapple/blob/main/docs/notebooks/pynapple-dandi-notebook.ipynb>` :bdg-link-primary:`Source <https://github.com/pynapple-org/pynapple>` :bdg-link-primary:`Twitter <https://twitter.com/thepynapple>`
- 
+:bdg-link-primary:`Docs <https://pynapple-org.github.io/pynapple/>` :bdg-link-primary:`DANDI Demo <https://pynapple-org.github.io/pynapple/generated/gallery/tutorial_pynapple_dandi/>` :bdg-link-primary:`Source <https://github.com/pynapple-org/pynapple>` :bdg-link-primary:`Twitter <https://twitter.com/thepynapple>`
+
 .. short_description_end
 
 .. image:: GraphicAbstract.png


### PR DESCRIPTION
The example notebook for Pynapple + DANDI has moved and the example is now a tutorial in the Pynapple core docs. This PR updates the broken link to the notebook to now point to the tutorial instead. 