### PR TITLE
Add basic page on NWB extensions catalog and proposals

### DIFF
--- a/docs/source/conf_extlinks.py
+++ b/docs/source/conf_extlinks.py
@@ -55,6 +55,8 @@ extlinks = {
     'ibl-website': ('https://www.internationalbrainlab.com/%s', '%s'),
     'mindscope-program': ('https://alleninstitute.org/what-we-do/brain-science/research/mindscope-program/%s', '%s'),
     'jupyter-book': ('https://jupyterbook.org/en/stable/%s', '%s'),
+    'nep-review': ('https://github.com/nwb-extensions/nep-review/%s', '%s'),
+    'nwb-tab': ('https://docs.google.com/document/d/e/2PACX-1vSynhRf8Zykfqnov81Ddi1tSo12RV4zYv3RRCEfLR2OqhpER_7PTmaoTNrRh5Coh8xg2LvwuriiHlsJ/pub/%s', '%s'),
 }
 
 # Use this for mapping for links to commonly used documentation

--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -1,0 +1,48 @@
+.. _extensions-catalog:
+
+********************************
+Extensions Catalog and Proposals
+********************************
+
+NWB Extensions (NDX) Catalog
+============================
+
+The :ndx-catalog:`NDX Catalog website <>` contains published
+extensions created by the community to add support for a wide variety of data types.
+Before creating your own extension, we recommend that you explore the Catalog to
+make sure that someone has not already created an extension that suits your needs
+or that you could build off of.
+
+Policies on Community-driven Development and Integration of New Neuroscience Technologies with NWB
+
+- `Sharing Guidelines: requirements and strategy for sharing format extensions for NWB <https://docs.google.com/document/d/e/2PACX-1vRxbT-EEAyYbQL3P0TREpySJkMhV7ea2-aRO75_s4PhqzxnJa9p-s0SzVWrlkzEBaTw82bgzZBtxEuj/pub>`_
+- `Sharing Strategies: standard practices and strategies for sharing format extensions for NWB <https://docs.google.com/document/d/e/2PACX-1vSpLLPQV2XlfT-Qnpi_aqLPJzRjCko6Ur0U5COCEAQg5uLIN0h5vej5EPtsf6UNx1qiAIKXPiIveSWo/pub>`_
+- `Versioning Guidelines: requirements and strategy for versioning namespaces for the NWB core schema and extensions <https://docs.google.com/document/d/e/2PACX-1vSH72zNSUBToVcZDRI4gF7h15ImWRffvj-ju1oEbxggPrEFJd5L6GQc-fRiVmIi42U742tgjcRk65jv/pub>`_
+
+NWB Enhancement Proposals (NEPs)
+================================
+
+The NWB data standard is not static but evolves to adapt to changing needs from the neuroscience community, 
+clarify ambiguities, and fix bugs, among others. Users can propose smaller changes, such as improvements to
+documentation or addition of a new optional field to an existing data type, on the 
+:nwb-schema-src:`NWB Schema GitHub repository <>`. Users can propose larger changes, such as addition of 
+several new data types to support a new data modality, or a major restructuring of existing data types, 
+through NWB Enhancement Proposals (NEPs).
+
+NEPs are often collaborative and led by members of the community to address a significant need by the 
+community. Here is a list of NEPs that have been started:
+
++--------+----------------------------------------------------------+-----------------+----------------------------------------------------------------------------------------------------------------+
+| NEP    | Title                                                    | Lead            | URLs                                                                                                           |
++========+==========================================================+=================+================================================================================================================+
+| NEP001 | Events and TTL Data                                      | Ryan Ly         | [google doc](https://docs.google.com/document/d/1qcsjyFVX9oI_746RdMoDdmQPu940s0YtDjb1en1Xtdw/edit?usp=sharing) |
+| NEP002 | Probe devices and channel mapping in extracellular ephys | Alessio Buccino | [google doc](https://docs.google.com/document/d/1q-haFEEHEgZpRoCzzQsuSWCKN4QfMsTzLnlptLaf-yw/edit?usp=sharing) |
++--------+----------------------------------------------------------+-----------------+----------------------------------------------------------------------------------------------------------------+
+
+Review of NEPs for acceptance to the NWB core data standard is led by the 
+:nwb-tab:`NWB Technical Advisory Board (TAB) <>`
+and involves several phases. To submit a NEP for review and explore previous NEP reviews, see the 
+:nep-review:`NEP Review GitHub repo <>`. For more information on the NEP process, see the following links:
+
+- `Proposal Review Process: process by which extensions to the NWB core standard are proposed, evaluated, reviewed, and accepted <https://docs.google.com/document/d/e/2PACX-1vR7v4ixgnaCsJSbKji5eGWxb5muzV1M82zA-D2IswZD_KOt7HiUjcXKpTko0lqcBAD-MTd44rqFCf-V/pub>`_
+- `Working Groups for Evaluating NEPs Policy: process for evaluation and review of NWB Extension Proposals (NEPs) by a review working group (RWG) to provide guidance and a formal framework for RWG members. <https://docs.google.com/document/d/e/2PACX-1vTpDnWFpD2YDuYKXzd-6svH6ceXNBz4wOauoZivvZpQgLPYBz6yv7-eihJceBtgGTDV_TcMX9xboNsm/pub>`_

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,6 +34,7 @@ for each of those tasks and point you to the best tools to use for your preferre
    :maxdepth: 1
 
    community_gallery/community_gallery.rst
+   extensions
    faq
 
 .. toctree::


### PR DESCRIPTION
Moving some content from https://www.nwb.org/policies-overview/ here. Goal is to point users here (including from https://github.com/nwb-extensions/nep-review) to learn more about current draft NEPs.