### PR TITLE
Fix typo in extensions doc

### DIFF
--- a/docs/source/extensions_tutorial/3_spec_api.rst
+++ b/docs/source/extensions_tutorial/3_spec_api.rst
@@ -111,14 +111,14 @@ list of :py:class:`~pynwb.spec.NWBDtypeSpec` objects to the ``dtype`` argument.
     spec = NWBDatasetSpec(
         doc='A custom NWB type',
         name='qux',
-        attribute=[
+        attributes=[
             NWBAttributeSpec('baz', 'a value for baz', 'text'),
-            ],
+        ],
         dtype=[
             NWBDtypeSpec('foo', 'column for foo', 'int'),
-            NWBDtypeSpec('bar', 'a column for bar', 'float')
-            ]
-        )
+            NWBDtypeSpec('bar', 'a column for bar', 'float'),
+        ],
+    )
 
 .. tip::
     Column-based tables are also possible and more flexible. See the documentation for :hdmf-docs:`DynamicTable <tutorials/plot_dynamictable_tutorial.html>`.


### PR DESCRIPTION
Fix typo, realign brackets, add trailing commas.