### PR TITLE
Fix broken link to versioning guide

### DIFF
--- a/docs/source/extensions_tutorial/2_create_extension_spec_walkthrough.rst
+++ b/docs/source/extensions_tutorial/2_create_extension_spec_walkthrough.rst
@@ -86,7 +86,7 @@ Here, after the initial imports, we are defining meta-data of the extension.
 Pay particular attention to ``version``. If you make changes to your extension
 after the initial release, you should increase the numbers in your version
 number, so that you can keep track of what exact version of the extension was
-used for each file. We recommend using a :nwb-main:`semantic versioning approach <versioning_guidelines>`.
+used for each file. We recommend using a :nwb-main:`semantic versioning approach <versioning-guidelines>`.
 
 Including types
 ~~~~~~~~~~~~~~~

--- a/docs/source/extensions_tutorial/2_create_extension_spec_walkthrough.rst
+++ b/docs/source/extensions_tutorial/2_create_extension_spec_walkthrough.rst
@@ -86,7 +86,7 @@ Here, after the initial imports, we are defining meta-data of the extension.
 Pay particular attention to ``version``. If you make changes to your extension
 after the initial release, you should increase the numbers in your version
 number, so that you can keep track of what exact version of the extension was
-used for each file. We recommend using a `semantic versioning approach <https://nwb-extensions.github.io/versioning_guidelines>`_.
+used for each file. We recommend using a :nwb-main:`semantic versioning approach <versioning_guidelines>`.
 
 Including types
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
A recent update to the pages of the NDX Catalog [broke a link](https://github.com/NeurodataWithoutBorders/nwb-overview/actions/runs/10129125671). This fixes it. 