### PR TITLE
Fix pynapple links

### DIFF
--- a/docs/source/tools/pynapple/pynapple.rst
+++ b/docs/source/tools/pynapple/pynapple.rst
@@ -6,7 +6,7 @@ pynapple
 .. short_description_start
 
 :ref:`analysistools-pynapple` is a unified toolbox for integrated analysis of multiple data sources. Designed to be "plug & play", users define and import their own time-relevant variables. Supported data sources include, but are not limited to, electrophysiology, calcium imaging, and motion capture data. Pynapple contains integrated functions for common neuroscience analyses, including cross-correlograms, tuning curves, decoding and perievent time histogram.
-:bdg-link-primary:`Docs <https://pynapple-org.github.io/pynapple/>` :bdg-link-primary:`DANDI Demo <https://pynapple-org.github.io/pynapple/generated/examples/tutorial_pynapple_dandi/>` :bdg-link-primary:`Source <https://github.com/pynapple-org/pynapple>` :bdg-link-primary:`Twitter <https://twitter.com/thepynapple>`
+:bdg-link-primary:`Docs <https://pynapple.org/>` :bdg-link-primary:`DANDI Demo <https://pynapple.org/examples/tutorial_pynapple_dandi.html>` :bdg-link-primary:`Source <https://github.com/pynapple-org/pynapple>` :bdg-link-primary:`Twitter <https://twitter.com/thepynapple>`
 
 .. image:: https://img.shields.io/github/stars/pynapple-org/pynapple?style=social
     :alt: GitHub Repo stars for pynapple


### PR DESCRIPTION
Pynapple links are broken due to their website migration. https://github.com/NeurodataWithoutBorders/nwb-overview/actions/runs/11648673850