### PR TITLE
Set theme back to sphinx_rtd_theme

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,6 +51,8 @@ html_favicon = 'img/favicon_96.png'
 # html_logo = None
 html_logo = 'img/logo_brain_transp.png'
 
+html_theme = "sphinx_rtd_theme"
+
 html_theme_options = {
     # 'analytics_id': 'G-XXXXXXXXXX',  #  Provided by Google in your dashboard
     # 'analytics_anonymize_ip': False,


### PR DESCRIPTION
A recent change in RTD reset the theme to the default alabaster theme. Somewhere, we lost the setting of `html_theme = "sphinx_rtd_theme"`. Probably when we deleted the `html_theme_path` variable which was deprecated.
